### PR TITLE
[FIX] Fixed the issue of missing patner_id in pos order.

### DIFF
--- a/pos_backend_partner/static/src/js/pos_partner.js
+++ b/pos_backend_partner/static/src/js/pos_partner.js
@@ -12,7 +12,7 @@ odoo.define('pos_backend_partner.partner_pos', function (require) {
     function set_client(message)  {
         var data = message.data;
         var partner_info = {
-            'id': parseInt(data.id, 10),
+            'id': parseInt(data.partner_id, 10),
             'name': data.name
         };
         pos_instance.get('selectedOrder').set_client(partner_info);
@@ -20,7 +20,6 @@ odoo.define('pos_backend_partner.partner_pos', function (require) {
     }
 
     function open_backend(message) {
-        console.log('open backend partner');
         //lookup action_id
         action_url = action_url || session.rpc(
             '/web/action/load', { "action_id":"pos_backend_partner.action_select_partner_pos"})


### PR DESCRIPTION
- Fixed the issue of missing patner_id in pos order.
- These are the steps to reproduce the issue:
      1. Start the POS GUI.
      2. select any product and then select any specific customer.
      3. Validate the pos order and complete the payment stuff.
      4. Now the see backend screen of pos order.
      5. You will get the latest POS order without the Customer, but we already assigned the customer in that order.